### PR TITLE
Fixed #3 -- fixed broken rst display in pypi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,18 +51,9 @@ See this `example script`_ and the `shell script`_.
 
 .. _example script: example.py
 
-.. literalinclude:: example.py
-   :language: python3
-   :linenos:
-
-
 .. _shell script: example.sh
 
-.. literalinclude:: example.sh
-   :language: bash
-   :linenos:
-
-::
+.. code-block:: python3
 
    $ ./example.py
    Usage: example.py [OPTIONS] COMMAND [ARGS]...


### PR DESCRIPTION
Greetings.

Thanks for nice package.

I've checked README with rst2html (usually helps identify that kind of problems):
```
 $ python setup.py --long-description | rst2html.py > /dev/null

<stdin>:54: (ERROR/3) Unknown directive type "literalinclude".
<stdin>:61: (ERROR/3) Unknown directive type "literalinclude".
```

So, my fix here in PR, tried in test pypi, worked fine:
https://monosnap.com/file/h6zEN89HNYMXmlS3SjlbrFK3Pt6pjS.png