### PR TITLE
Feature/universal wheel

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -12,7 +12,11 @@ git --version
 
 version=$1
 
-sed -i "s/__version__ = .*/__version__ = '${version}'/" */__init__.py
+if [[ "$OSTYPE" == "darwin"* ]]; then
+	sed -i "" "s/__version__ = .*/__version__ = '${version}'/" */__init__.py
+else
+	sed -i "s/__version__ = .*/__version__ = '${version}'/" */__init__.py
+fi
 
 # Do not tag/push on Go CD
 if [ -z "$GO_PIPELINE_LABEL" ]; then

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ def read_version(package):
             if line.startswith('__version__ = '):
                 return line.split()[-1].strip().strip('\'')
 
+
 NAME = 'clickclick'
 MAIN_PACKAGE = 'clickclick'
 VERSION = read_version(MAIN_PACKAGE)


### PR DESCRIPTION
Fix for https://github.com/zalando/python-clickclick/issues/12  - 
* added setup.cfg to allow building py2 compatible wheels 
* fixed a minor flake8 complaint to prevent ./release.sh from failing on flake8 errors