### PR TITLE
Include LICENSE in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include *.txt
 include *.rst
+include LICENSE
 recursive-include clickclick *.py


### PR DESCRIPTION
This makes setuptools include LICENSE in the sdist tarball, which makes
it easier to see which license applies to python-clickclick when
obtaining it as a tarball.